### PR TITLE
fix(ci): mirror main with reset --hard so VPS deploy survives server …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,13 @@ jobs:
           script: |
             set -e
             cd /var/www/app
-            git pull origin main
+            # Mirror main exactly. `reset --hard` (not `pull`) so any drift in tracked
+            # files on the server — e.g. a package.json hand-edited during setup — is
+            # overwritten instead of blocking the deploy with a merge conflict.
+            # Untracked files (.env, .env.production, dist/, node_modules/) are NOT
+            # touched: no `git clean` is run.
+            git fetch origin main
+            git reset --hard origin/main
 
             # ----- Backend -----
             cd /var/www/app/backend


### PR DESCRIPTION
…drift

The VPS had backend/package.json hand-edited during setup (start script fix), so `git pull` aborted with "local changes would be overwritten". Replace pull with `git fetch` + `git reset --hard origin/main` so the deploy box mirrors main exactly. Untracked files (.env, .env.production, dist/, node_modules/) are preserved — no `git clean` is run.