### PR TITLE
fix(frontend): stop splitting React vendor chunks (blank page / forwa…

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,25 +11,16 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
-        // Split heavy, independent pieces into their own chunks so the main app
-        // bundle is smaller and each piece caches independently between deploys.
         manualChunks(id) {
-          // The India GeoJSON is ~23MB on its own; isolate it so it never bloats
-          // the main app chunk and is cached separately from app code.
+          // ONLY isolate the ~23MB India GeoJSON (pure data, no React) so it stays
+          // out of the main app chunk and caches separately.
+          //
+          // Do NOT split vendor libs (recharts/react/dnd) into separate chunks:
+          // separating React-dependent code from React breaks chunk init order and
+          // throws "Cannot read properties of undefined (reading 'forwardRef')" at
+          // runtime (blank page). Everything except india.json uses Vite's default
+          // chunking, which keeps React and its dependents together.
           if (id.includes("assets/india.json")) return "india-geo";
-          if (id.includes("node_modules")) {
-            if (id.includes("recharts") || id.includes("/d3-")) return "charts";
-            if (id.includes("@dnd-kit")) return "dnd";
-            // Keep the whole React ecosystem together so there is exactly one
-            // React/context instance — splitting these risks runtime errors.
-            if (
-              /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|react-redux|@reduxjs[\\/]toolkit|scheduler|redux)[\\/]/.test(
-                id,
-              )
-            ) {
-              return "react-vendor";
-            }
-          }
           return undefined;
         },
       },


### PR DESCRIPTION
…rdRef crash)

Splitting recharts into a separate `charts` chunk from React caused "Cannot read properties of undefined (reading 'forwardRef')" at runtime, white-screening the deployed app. manualChunks now ONLY isolates the ~23MB india.json (pure data); everything else uses Vite's default chunking, keeping React and its dependents in one chunk.