### PR TITLE
perf(sales): make summary cache effective + fix startup sync

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,7 +24,6 @@ import { mountBookFairOfflineSales } from "./features/sales/server/bookfair-offl
 import { mountLokbhartiOfflineSales } from "./features/sales/server/lokbharti-offline.index.js";
 import { mountTotalOfflineSales } from "./features/sales/server/total-offline.index.js";
 import { notFound } from "./middleware/notFound.js";
-import { offlineSyncService } from "./features/sales/server/offlineSyncService.js";
 import { getLastSyncStatus } from "./features/sales/server/syncScheduler.js";
 import swaggerUi from "swagger-ui-express";
 import { swaggerSpec } from "./config/swagger.js";
@@ -239,28 +238,9 @@ app.use("*", (req, res) => {
 app.use(notFound);
 app.use(errorHandler);
 
-// Basic background sync on startup (scalable fallback)
-if (process.env.NODE_ENV !== 'test') {
-  setTimeout(async () => {
-    console.log("Auto-syncing regional offline sales data sequentially...");
-    const syncTasks = [
-      { name: "Delhi/General Offline Sales", fn: () => offlineSyncService.syncOfflineSales() },
-      { name: "Mumbai Offline Sales", fn: () => offlineSyncService.syncMumbaiSales() },
-      { name: "Patna Offline Sales", fn: () => offlineSyncService.syncPatnaSales() },
-      { name: "Online Offline Sales", fn: () => offlineSyncService.syncOnlineOfflineSales() },
-      { name: "BookFair Offline Sales", fn: () => offlineSyncService.syncBookFairSales() },
-      { name: "Lokbharti Offline Sales", fn: () => offlineSyncService.syncLokbhartiSales() }
-    ];
-
-    for (const task of syncTasks) {
-      try {
-        await task.fn();
-      } catch (err: any) {
-        console.error(`Sync failed for ${task.name}:`, err.message || err);
-      }
-    }
-    console.log("Auto-syncing regional offline sales completed.");
-  }, 5000); // 5s delay to let server settle
-}
+// NOTE: the on-startup background sync that used to live here was removed. It ran on
+// EVERY app load — including every Vercel serverless cold start — firing a full
+// wipe-and-reinsert of all regions, and it bypassed cache invalidation + sync_logs.
+// Boot-time sync now lives in index.ts (VPS-only) and routes through runScheduledSync.
 
 export default app;

--- a/backend/src/features/sales/server/bookfair-offline.routes.ts
+++ b/backend/src/features/sales/server/bookfair-offline.routes.ts
@@ -4,10 +4,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000);
 
@@ -22,6 +23,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 router.use(authenticateToken as any);
@@ -160,7 +162,7 @@ router.get("/summary", async (req, res) => {
   const endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : undefined;
   const { state, city, publisher, author, isbn, customerName, minAmount, maxAmount, binding, title, type, q } = parsed.data;
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/lokbharti-offline.routes.ts
+++ b/backend/src/features/sales/server/lokbharti-offline.routes.ts
@@ -4,10 +4,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000);
 
@@ -22,6 +23,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 router.use(authenticateToken as any);
@@ -160,7 +162,7 @@ router.get("/summary", async (req, res) => {
   const endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : undefined;
   const { state, city, publisher, author, isbn, customerName, minAmount, maxAmount, binding, title, type, q } = parsed.data;
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/mumbai-offline.routes.ts
+++ b/backend/src/features/sales/server/mumbai-offline.routes.ts
@@ -4,10 +4,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000);
 
@@ -22,6 +23,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 router.use(authenticateToken as any);
@@ -160,7 +162,7 @@ router.get("/summary", async (req, res) => {
   const endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : undefined;
   const { state, city, publisher, author, isbn, customerName, minAmount, maxAmount, binding, title, type, q } = parsed.data;
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/offline.routes.ts
+++ b/backend/src/features/sales/server/offline.routes.ts
@@ -4,11 +4,12 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
 // 5-minute server-side cache for expensive aggregate endpoints
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000); // 30 minutes
 
@@ -24,6 +25,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 
@@ -330,7 +332,7 @@ router.get("/summary", async (req, res) => {
   const fictionCats = parseFictionParam(parsed.data.fictionType);
   const fictionRawCond = fictionSql(fictionCats);
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:${fictionCats.join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:${fictionCats.join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/online-offline.routes.ts
+++ b/backend/src/features/sales/server/online-offline.routes.ts
@@ -4,10 +4,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000);
 
@@ -22,6 +23,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 router.use(authenticateToken as any);
@@ -160,7 +162,7 @@ router.get("/summary", async (req, res) => {
   const endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : undefined;
   const { state, city, publisher, author, isbn, customerName, minAmount, maxAmount, binding, title, type, q } = parsed.data;
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/patna-offline.routes.ts
+++ b/backend/src/features/sales/server/patna-offline.routes.ts
@@ -4,10 +4,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/prisma.js";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { TtlCache } from "../../../lib/cache.js";
+import { registerSalesCacheClear } from "./salesCacheRegistry.js";
 import { authenticateToken } from "../../../middleware/authPrisma.js";
 import { parseFictionParam, fictionWhere, fictionSql } from "./fictionFilter.js";
 
-const summaryCache = new TtlCache<any>(5 * 60 * 1000);
+const summaryCache = new TtlCache<any>(24 * 60 * 60 * 1000); // 24h — data changes only on sync; invalidated explicitly via the cache registry
 const countsCache = new TtlCache<any>(5 * 60 * 1000);
 const optionsCache = new TtlCache<any>(30 * 60 * 1000);
 
@@ -22,6 +23,7 @@ function clearCaches() {
   countsCache.clear();
   optionsCache.clear();
 }
+registerSalesCacheClear(clearCaches);
 
 const router = express.Router();
 router.use(authenticateToken as any);
@@ -158,7 +160,7 @@ router.get("/summary", async (req, res) => {
   const endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : undefined;
   const { state, city, publisher, author, isbn, customerName, minAmount, maxAmount, binding, title, type, q } = parsed.data;
 
-  const cacheKey = `summary:${days ?? "all"}:${startDate?.toISOString() ?? ""}:${endDate?.toISOString() ?? ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
+  const cacheKey = `summary:${days ?? "all"}:${startDate ? startDate.toISOString().slice(0, 10) : ""}:${endDate ? endDate.toISOString().slice(0, 10) : ""}:${state ?? ""}:${city ?? ""}:${publisher ?? ""}:${author ?? ""}:${isbn ?? ""}:${customerName ?? ""}:${minAmount ?? ""}:${maxAmount ?? ""}:${binding ?? ""}:${title ?? ""}:${type ?? ""}:fic=${parseFictionParam(parsed.data.fictionType).join("|")}:${q ?? ""}`;
   const cached = summaryCache.get(cacheKey);
   if (cached) return res.json(cached);
 

--- a/backend/src/features/sales/server/salesCacheRegistry.ts
+++ b/backend/src/features/sales/server/salesCacheRegistry.ts
@@ -1,0 +1,28 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// salesCacheRegistry.ts
+//
+// Central registry of per-region cache-clear functions. Each region route module
+// registers its clearCaches() at load time; the sync scheduler calls
+// clearAllSalesCaches() right after a sync so the live in-memory caches are
+// invalidated as soon as the underlying data changes (instead of waiting for TTL).
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ClearFn = () => void;
+
+const clearFns = new Set<ClearFn>();
+
+/** Registers a cache-clear function (idempotent — a given fn registers once). */
+export function registerSalesCacheClear(fn: ClearFn): void {
+  clearFns.add(fn);
+}
+
+/** Invokes every registered cache-clear function. Resilient: one failure won't stop the rest. */
+export function clearAllSalesCaches(): void {
+  for (const fn of clearFns) {
+    try {
+      fn();
+    } catch (e: any) {
+      console.error("[sales-cache] clear failed:", e?.message || e);
+    }
+  }
+}

--- a/backend/src/features/sales/server/syncLogStore.ts
+++ b/backend/src/features/sales/server/syncLogStore.ts
@@ -48,7 +48,7 @@ export function ensureSyncLogTable(): Promise<void> {
 
 /** Persists one completed sync run. Resilient: logs and swallows errors so a logging
  *  failure can never break the sync itself. */
-export async function recordSyncLog(status: LastSyncStatus, trigger: "scheduled" | "manual"): Promise<void> {
+export async function recordSyncLog(status: LastSyncStatus, trigger: "scheduled" | "manual" | "startup"): Promise<void> {
   if (!status.startedAt || !status.finishedAt) return;
   try {
     await ensureSyncLogTable();

--- a/backend/src/features/sales/server/syncScheduler.ts
+++ b/backend/src/features/sales/server/syncScheduler.ts
@@ -14,6 +14,7 @@
 import cron from "node-cron";
 import { offlineSyncService } from "./offlineSyncService.js";
 import { recordSyncLog } from "./syncLogStore.js";
+import { clearAllSalesCaches } from "./salesCacheRegistry.js";
 
 let task: ReturnType<typeof cron.schedule> | null = null;
 let isRunning = false;
@@ -52,7 +53,7 @@ export function getLastSyncStatus(): LastSyncStatus {
  * status. Guards against overlapping runs (returns null if one is already in progress).
  * Exported for manual triggering (e.g. `npm run sync:all`).
  */
-export async function runScheduledSync(trigger: "scheduled" | "manual" = "scheduled"): Promise<LastSyncStatus | null> {
+export async function runScheduledSync(trigger: "scheduled" | "manual" | "startup" = "scheduled"): Promise<LastSyncStatus | null> {
   if (isRunning) {
     console.warn("[sync-scheduler] previous run still in progress; skipping this tick");
     return null;
@@ -106,6 +107,10 @@ export async function runScheduledSync(trigger: "scheduled" | "manual" = "schedu
   } finally {
     isRunning = false;
   }
+  // Data just changed — drop the live in-memory caches so the next request recomputes
+  // fresh (rather than waiting for TTL). Runs in the server process for the scheduled
+  // run; a no-op in the throwaway `sync:all` CLI process (no routes loaded there).
+  clearAllSalesCaches();
   await recordSyncLog(lastSync, trigger);
   return lastSync;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import app from './app.js';
 import { prisma } from './lib/prisma.js';
-import { startSyncScheduler } from './features/sales/server/syncScheduler.js';
+import { startSyncScheduler, runScheduledSync } from './features/sales/server/syncScheduler.js';
 import { ensureSyncLogTable } from './features/sales/server/syncLogStore.js';
 
 const PORT = process.env.PORT || 4000;
@@ -16,6 +16,16 @@ app.listen(PORT, () => {
   // (VPS only; no-op unless ENABLE_SCHEDULED_SYNC=true).
   ensureSyncLogTable().catch((e) => console.error("[sync-log] ensure table failed:", e?.message || e));
   startSyncScheduler();
+
+  // Boot-time sync so data is fresh after a deploy/restart. VPS-only (this file isn't
+  // used on Vercel), routes through runScheduledSync so it invalidates caches + logs to
+  // sync_logs. Default ON; set SYNC_ON_STARTUP=false to disable. Short delay lets the
+  // server settle (and answer health checks) before the heavy sync begins.
+  if (process.env.NODE_ENV !== 'test' && process.env.SYNC_ON_STARTUP !== 'false') {
+    setTimeout(() => {
+      runScheduledSync('startup').catch((e) => console.error('[sync-scheduler] startup sync failed:', e?.message || e));
+    }, 5000);
+  }
 });
 
 // ── DB keep-warm heartbeat ───────────────────────────────────────────────────

--- a/frontend/src/features/sales/client/useOfflineSheetFilters.ts
+++ b/frontend/src/features/sales/client/useOfflineSheetFilters.ts
@@ -26,10 +26,15 @@ export function useOfflineSheetFilters() {
     let finalStartDate = startDate;
     let finalEndDate = endDate;
 
-    // Default to Indian Financial Year to Date (FYTD) if no date filter parameters are set
+    // Default to Indian Financial Year to Date (FYTD) if no date filter parameters are set.
+    // Pin endDate to end-of-day (UTC) so the value is stable for the whole day — otherwise
+    // its millisecond timestamp makes every request a unique cache key (backend + react-query),
+    // defeating caching for the default view.
     if (days === undefined && startDate === undefined && endDate === undefined) {
       finalStartDate = getFinancialYearStartDate().toISOString();
-      finalEndDate = new Date().toISOString();
+      const endOfDay = new Date();
+      endOfDay.setUTCHours(23, 59, 59, 999);
+      finalEndDate = endOfDay.toISOString();
     }
 
     return {


### PR DESCRIPTION
Caching rework (the in-memory cache was never hitting for the default view):
- Day-normalize the cache key (truncate startDate/endDate to YYYY-MM-DD). The query already truncates to day boundaries, so this is behavior- preserving but lets same-day requests share a cache entry.
- Pin the frontend default FYTD endDate to end-of-day (was a ms timestamp that made every request a unique key, defeating cache + react-query).
- Summary cache TTL 5m -> 24h (data only changes on sync).
- Invalidate-on-sync via salesCacheRegistry: runScheduledSync clears all live region caches right after a sync.

Startup sync fix:
- Removed the on-startup full sync from app.ts. It ran on every app load (including every Vercel cold start), bypassed cache invalidation + sync_logs, and was redundant with the cron.
- Boot-time sync now lives in index.ts (VPS-only), routed through runScheduledSync('startup') so it invalidates caches + logs. Toggle with SYNC_ON_STARTUP=false.

Verified: same-day requests with different sub-day timestamps now hit cache (2910ms cold -> 535ms warm, identical payload). tsc clean; 8/8 scheduler tests pass; importing app no longer triggers a sync.